### PR TITLE
Add support for unrolled props

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,19 @@ module.exports = function () {
     def.poll = function () { queue.push(function (r) { r.poll() }) }
     def.clear = function (opts) { queue.push(function (r) { r.clear(opts) }) }
     def.prop = function (key) {
-      return function (context, props) { return props[key] }
+      return function (context, props) {
+        if(props[key]){
+          return props[key]
+        }else{
+          // missing key could be speical case unrolled uniform prop
+          // https://github.com/regl-project/regl/issues/258
+          // https://github.com/regl-project/regl/issues/373
+          var matches = key.match(/(?<prop>.+)\[(?<index>.+)\]/i)
+          if(matches){
+            return props[matches.groups.prop][matches.groups.index]
+          }
+        }
+      }
     }
     def.props = def.prop
     def.context = function (key) {


### PR DESCRIPTION
This PR adds a guard for unrolled props. At definition time unrolled
uniforms are defined like:

```
uniforms: {
  ...[...new Array(22)].reduce((acc, val, index) => {
      acc[`joints[${index}]`] = regl.prop(`joints[${index}]`);
      return acc;
   }, {}),
}
```

The prop key is then `joints[0]`. The props record passed to
`(context, props)` only has the `joints` key.

More information
https://github.com/regl-project/regl/issues/258
https://github.com/regl-project/regl/issues/373