### PR TITLE
Add return values for resource creation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,8 +75,12 @@ module.exports = function () {
       }
       return function () {
         var args = arguments
-        if (f) f.apply(null,args)
-        else queue.push(function (r) { f.apply(null,args) })
+        if (f) {
+          if(key === '()') f.apply(null,args)
+          else return f;
+        }else{
+          queue.push(function (r) { f.apply(null,args) })
+        }
       }
     }
   }
@@ -93,7 +97,10 @@ module.exports = function () {
       }
       var r = function () {
         var args = arguments
-        if (f) f.apply(null,args)
+        if (f){
+          if(key === '()') f.apply(null,args)
+          else return f;
+        }
         else queue.push(function (r) { f.apply(null,args) })
       }
       for (var i = 0; i < methods.length; i++) {


### PR DESCRIPTION
Resources like textures should return a value instead of a void `apply` call. I had a case like the following:

```
const draw = regl({
  uniforms:{
    tex: regl.texture({
      width: grassPNG.width,
      height: grassPNG.height,
      data: grassPNG.data,
      mag: 'linear',
      min: 'linear',
      wrap: ['repeat', 'repeat']
    });
})

draw();
```

the `uniforms.tex` was throwing an error when `draw()` was called because the expected texture resource was not being returned. 